### PR TITLE
updated apache2 template

### DIFF
--- a/provisioning/roles/apache/tasks/main.yml
+++ b/provisioning/roles/apache/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - name: enable FastCGI module
   apache2_module: name=proxy_fcgi
+
+- name: enable Rewrite module
+  apache2_module: name=rewrite

--- a/provisioning/roles/webapp/templates/apache2.vhost.j2
+++ b/provisioning/roles/webapp/templates/apache2.vhost.j2
@@ -7,39 +7,39 @@
 
     # used for http basic auth and oauth2 bearer token
     SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
-    
-    SetEnv          SYMFONY__DATABASE__USER {{ DBUSER }}
-    SetEnv          SYMFONY__DATABASE__PASSWORD {{ DBPASSWORD }}
+
+    SetEnv SYMFONY__DATABASE__USER {{ DBUSER }}
+    SetEnv SYMFONY__DATABASE__PASSWORD {{ DBPASSWORD }}
 
     DocumentRoot {{ APPWEBROOT }}
     <Directory {{ APPWEBROOT }}>
-    AllowOverride None
-    Require all granted
+        AllowOverride None
+        Require all granted
 
-    ## Start directives copied from standard Sf .htaccess
-    DirectoryIndex app.php
-    <IfModule mod_rewrite.c>
-        RewriteEngine On
+        ## Start directives copied from standard Sf .htaccess
+        DirectoryIndex app.php
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
 
-        RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
-        RewriteRule ^(.*) - [E=BASE:%1]
+            RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
+            RewriteRule ^(.*) - [E=BASE:%1]
 
-        RewriteCond %{ENV:REDIRECT_STATUS} ^$
-        RewriteRule ^app\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
+            RewriteCond %{ENV:REDIRECT_STATUS} ^$
+            RewriteRule ^app\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
 
-        RewriteCond %{REQUEST_FILENAME} -f
-        RewriteCond %{REQUEST_URI} .*\.php
-        # Need to add the phpfpm call here so that php files (including app_dev.php) are passed to FPM
-        RewriteRule ^(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/%{REQUEST_FILENAME} [P,END]
+            RewriteCond %{REQUEST_FILENAME} -f
+            RewriteCond %{REQUEST_URI} .*\.php
+            # Need to add the phpfpm call here so that php files (including app_dev.php) are passed to FPM
+            RewriteRule ^(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/%{REQUEST_FILENAME} [P,END]
 
-        RewriteCond %{REQUEST_FILENAME} -f
-        RewriteRule .? - [L]
+            RewriteCond %{REQUEST_FILENAME} -f
+            RewriteRule .? - [L]
 
-        RewriteRule .? %{ENV:BASE}/app.php [L]
+            RewriteRule .? %{ENV:BASE}/app.php [L]
 
-        # The main phpfpm call is added at the end to pass php requests through to FPM
-        RewriteRule ^(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/%{REQUEST_FILENAME} [P,END]
-    </IfModule>
-    ## End directives copied from standard Sf .htaccess
-  </Directory>
+            # The main phpfpm call is added at the end to pass php requests through to FPM
+            RewriteRule ^(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/%{REQUEST_FILENAME} [P,END]
+        </IfModule>
+        ## End directives copied from standard Sf .htaccess
+    </Directory>
 </VirtualHost>

--- a/provisioning/roles/webapp/templates/apache2.vhost.j2
+++ b/provisioning/roles/webapp/templates/apache2.vhost.j2
@@ -1,14 +1,45 @@
 <VirtualHost *:80>
-    ServerName      Symfony
-    DocumentRoot    "{{ APPWEBROOT }}"
+    ServerName Symfony
+    ServerAlias Symfony
+
+    ErrorLog /var/log/apache2/project_error.log
+    CustomLog /var/log/apache2/project_access.log combined
+
+    # used for http basic auth and oauth2 bearer token
+    SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
+    
     SetEnv          SYMFONY__DATABASE__USER {{ DBUSER }}
     SetEnv          SYMFONY__DATABASE__PASSWORD {{ DBPASSWORD }}
 
-    ProxyPassMatch ^/(.+\.(hh|php)(/.*)?)$ fcgi://127.0.0.1:9000/{{ APPWEBROOT }}/$1
+    DocumentRoot {{ APPWEBROOT }}
+    <Directory {{ APPWEBROOT }}>
+    AllowOverride None
+    Require all granted
 
-    <Directory "{{ APPWEBROOT }}">
-        AllowOverride All
-        Require all granted
+    ## Start directives copied from standard Sf .htaccess
+    DirectoryIndex app.php
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
 
-    </Directory>
+        RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
+        RewriteRule ^(.*) - [E=BASE:%1]
+
+        RewriteCond %{ENV:REDIRECT_STATUS} ^$
+        RewriteRule ^app\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
+
+        RewriteCond %{REQUEST_FILENAME} -f
+        RewriteCond %{REQUEST_URI} .*\.php
+        # Need to add the phpfpm call here so that php files (including app_dev.php) are passed to FPM
+        RewriteRule ^(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/%{REQUEST_FILENAME} [P,END]
+
+        RewriteCond %{REQUEST_FILENAME} -f
+        RewriteRule .? - [L]
+
+        RewriteRule .? %{ENV:BASE}/app.php [L]
+
+        # The main phpfpm call is added at the end to pass php requests through to FPM
+        RewriteRule ^(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/%{REQUEST_FILENAME} [P,END]
+    </IfModule>
+    ## End directives copied from standard Sf .htaccess
+  </Directory>
 </VirtualHost>


### PR DESCRIPTION
to support
- http authorization headers   (useful for http basic auth and oauth2 bearer token)
- being able to access to the production path  (mywebsite.com/backend/channel  without the app.php ) 
- living without the .htaccess (with provide slightly better performance)
