### PR TITLE
removed unused port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,6 @@ PYTHONUNBUFFERED=1 ansible-playbook --connection=local -i "[default] $(hostname)
 END
   end
 
-  config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.network "private_network", ip: "192.168.50.4"
 


### PR DESCRIPTION
I'm pretty sure we don't use it anymore and it was here because of some intermediate step testing ? 

If not, a comment in the vagrant file to explain the purpose of that port forwarding would be welcome 
