### PR TITLE
Fixed service failing to restart on provisioning for some hosts

### DIFF
--- a/provisioning/roles/apache/handlers/main.yml
+++ b/provisioning/roles/apache/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart Apache
-  service: name=apache2 state=restarted
+  command: service apache2 restart
 

--- a/provisioning/roles/hhvm/handlers/main.yml
+++ b/provisioning/roles/hhvm/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart HHVM
-  service: name=hhvm state=restarted
+  command: service hhvm restart

--- a/provisioning/roles/php/handlers/main.yml
+++ b/provisioning/roles/php/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart PHP5-FPM
-  service: name=php5-fpm state=restarted
+  command: service php5-fpm restart

--- a/provisioning/roles/vagrantbox/handlers/main.yml
+++ b/provisioning/roles/vagrantbox/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart SSH
-  service: name=ssh state=restarted
+  command: service ssh restart
 
 - name: enable swapping
   command: swapon -a


### PR DESCRIPTION
Fixes the service failed to restart error ("all hosts have failed") during provisioning for some hosts / ansible / vagrant version
